### PR TITLE
Makes karma easier in slack

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -33,6 +33,7 @@ Lita.configure do |config|
   normalized_karma_user_term = ->(user_id, user_name) { "#{user_name}" }
 
   config.handlers.karma.cooldown = nil
+  config.handlers.karms.term_pattern = /^@?(.*?)[: ]*(\+\+|--)\s*$/
   config.handlers.karma.term_normalizer = lambda do |full_term|
     term = full_term.to_s.strip.sub(/[<:]([^>:]+)[>:]/, '\1')
     user = Lita::User.fuzzy_find(term.sub(/\A@/, ''))


### PR DESCRIPTION
Slack auto-appends `: ` to the end of @-references, so this adds
to the karma plugin so it accepts something like "@username: ++".