### PR TITLE
Adds better regex for karma term

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -34,7 +34,7 @@ Lita.configure do |config|
 
   config.handlers.karma.cooldown = nil
   # default term_pattern: /[\[\]\p{Word}\._|\{\}]{2,}/
-  config.handlers.karma.term_pattern = /^@?(.*?)[: ]*(\+\+|--)\s*$/
+  config.handlers.karma.term_pattern = /[\[\]\p{Word}\._|\{\}]{2,}:?\s*/
   config.handlers.karma.term_normalizer = lambda do |full_term|
     term = full_term.to_s.strip.sub(/[<:]([^>:]+)[>:]/, '\1')
     user = Lita::User.fuzzy_find(term.sub(/\A@/, ''))


### PR DESCRIPTION
Going back to the default, but modifying it slightly to include
the additional `: ` possibility, but just for matching. The karma
normalizer is still the same.