### PR TITLE
I tested it this time and everything

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -36,7 +36,7 @@ Lita.configure do |config|
   # default term_pattern: /[\[\]\p{Word}\._|\{\}]{2,}/
   config.handlers.karma.term_pattern = /[\[\]\p{Word}\._|\{\}]{2,}:?\s*/
   config.handlers.karma.term_normalizer = lambda do |full_term|
-    term = full_term.to_s.strip.sub(/([^:]+)/, '\1')
+    term = full_term.to_s.strip.sub(/([:]+)/, '')
     user = Lita::User.fuzzy_find(term.sub(/\A@/, ''))
 
     if user


### PR DESCRIPTION
This will allow karma to accept strings like "@username: ++" and
give karma to "username" and not "username:". Tested in lita-dev.

that `\1` matcher wasn't working.